### PR TITLE
Fixed bug where link ended in capitals

### DIFF
--- a/Plugins/ImageToClipboard/ImageToClipboard.plugin.js
+++ b/Plugins/ImageToClipboard/ImageToClipboard.plugin.js
@@ -59,7 +59,7 @@ class Plugin {
 			var children = Array.isArray(ele.props.children) ? ele.props.children : [ele.props.children];
 			for (var i = 0; i < children.length; i++) {
 				if (children[i] && children[i].props && children[i].props.href && children[i].type && children[i].type.displayName == "NativeLinkGroup") {
-					var imageLink = children[i].props.href;
+					var imageLink = children[i].props.href.toLowerCase();
 					if (imageLink.endsWith('.png') || imageLink.endsWith('.jpg') || imageLink.endsWith('.jpeg')) {
 						var item = $(this.contextItem).on("click."+this.getShortName(), ()=>{$(context).hide();this.copyToClipboard(imageLink);});
 						$(context).find('.item:contains("Copy Link")').after(item)

--- a/Plugins/ImageToClipboard/ImageToClipboard.plugin.js
+++ b/Plugins/ImageToClipboard/ImageToClipboard.plugin.js
@@ -6,7 +6,7 @@ class Plugin {
 	getName(){return "Image To Clipboard"}
 	getShortName() {return "i2c"}
 	getDescription(){return "Copies images (png/jpg) directly to clipboard. Support Server: bit.ly/ZeresServer"}
-	getVersion(){return "0.2.2"}
+	getVersion(){return "0.2.3"}
 	getAuthor(){return "Zerebos"}
 
 	constructor() {


### PR DESCRIPTION
If the link ends in something like `.PNG`, the plugin doesn't work