### PR TITLE
Removed getVersion() from BetterFormattingRedux

### DIFF
--- a/Plugins/BetterFormattingRedux/BetterFormattingRedux.plugin.js
+++ b/Plugins/BetterFormattingRedux/BetterFormattingRedux.plugin.js
@@ -31,7 +31,6 @@ var BetterFormattingRedux = (() => {
         getName() {return config.info.name;}
         getAuthor() {return config.info.authors.map(a => a.name).join(", ");}
         getDescription() {return config.info.description;}
-        getVersion() {return config.info.version;}
         load() {
             const title = "Library Missing";
             const ModalStack = BdApi.findModuleByProps("push", "update", "pop", "popWithKey");


### PR DESCRIPTION
getVersion() caused the plugin not to load at all. I'm not sure if invalid JSON is causing it, but removing getVersion() (for now) fixes the problem with it not loading.

The BetterFormattingRedux.config.json files also needs to be deleted and reloaded (or just updated), but I'm assuming that's what happens when plugins are updated.