### PR TITLE
Fixed spacing around the button and adjusted opacity

### DIFF
--- a/Plugins/SendButton/SendButton.plugin.js
+++ b/Plugins/SendButton/SendButton.plugin.js
@@ -64,10 +64,11 @@ module.exports = (() => {
 	position: absolute;
 	right: 12px;
 	top: 8px;
+	padding-left: 17px;
 }
 
 .send-button img {
-	opacity: 0.5;
+	opacity: 0.75;
 	width: 100%;
 	transition: all 200ms ease;
 }

--- a/src/plugins/SendButton/styles.css
+++ b/src/plugins/SendButton/styles.css
@@ -6,10 +6,11 @@
 	position: absolute;
 	right: 12px;
 	top: 8px;
+	padding-left: 17px;
 }
 
 .send-button img {
-	opacity: 0.5;
+	opacity: 0.75;
 	width: 100%;
 	transition: all 200ms ease;
 }


### PR DESCRIPTION
This commit fixes [this](https://github.com/rauenzi/BetterDiscordAddons/issues/240) issue by adding padding to the left.
I also changed the opacity of the button to blend in with the other ones more easily.

Note: I messed up my original fork so I just redid it. I also made the change in the source files now.