### PR TITLE
Fix search icon not centered

### DIFF
--- a/Plugins/ServerSearch/ServerSearch.plugin.js
+++ b/Plugins/ServerSearch/ServerSearch.plugin.js
@@ -136,7 +136,7 @@ module.exports = (() => {
         <div tabindex="0" class="circleButtonMask-1_597P wrapper-25eVIn" role="button" style="border-radius: 25px; background-color: rgb(47, 49, 54);">
             <svg width="48" height="48" viewBox="0 0 48 48" class="svg-1X37T1 da-svg">
                 <foreignObject mask="url(#782e4422-824c-4b8f-bbe5-18c62c59a77f)" x="0" y="0" width="48" height="48">
-                    <div tabindex="0" class="circleIconButton-1QV--U" role="button" style="background: none;">
+                    <div tabindex="0" class="circleIconButton-1QV--U" role="button" style="background: none; padding: 12px;">
                         <svg name="Search" width="24" height="24" viewBox="0 0 18 18">
                             <g fill="none" fill-rule="evenodd">
                                 <path fill="white" d="M3.60091481,7.20297313 C3.60091481,5.20983419 5.20983419,3.60091481 7.20297313,3.60091481 C9.19611206,3.60091481 10.8050314,5.20983419 10.8050314,7.20297313 C10.8050314,9.19611206 9.19611206,10.8050314 7.20297313,10.8050314 C5.20983419,10.8050314 3.60091481,9.19611206 3.60091481,7.20297313 Z M12.0057176,10.8050314 L11.3733562,10.8050314 L11.1492281,10.5889079 C11.9336764,9.67638651 12.4059463,8.49170955 12.4059463,7.20297313 C12.4059463,4.32933105 10.0766152,2 7.20297313,2 C4.32933105,2 2,4.32933105 2,7.20297313 C2,10.0766152 4.32933105,12.4059463 7.20297313,12.4059463 C8.49170955,12.4059463 9.67638651,11.9336764 10.5889079,11.1492281 L10.8050314,11.3733562 L10.8050314,12.0057176 L14.8073185,16 L16,14.8073185 L12.2102538,11.0099776 L12.0057176,10.8050314 Z"></path>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/20037329/127049771-528e633d-81f2-47f2-b75a-fbb604d45084.png)

**System Information**
![image](https://user-images.githubusercontent.com/20037329/127050011-05769918-1b17-43d1-9ae3-a1a5a4bf1455.png)



Not sure if this is only for me or for others as well but it was not centered when I installed it