### PR TITLE
[BlurNSFW] Hover on main part of channels.

### DIFF
--- a/Plugins/BlurNSFW/BlurNSFW.plugin.js
+++ b/Plugins/BlurNSFW/BlurNSFW.plugin.js
@@ -68,7 +68,8 @@ module.exports = (() => {
             this.styleTemplate = `
             {{blurOnFocus}}
             img.blur:hover,
-            video.blur:hover {
+            video.blur:hover,
+            a:hover + div > .blur {
                 transition: {{time}}ms cubic-bezier(.2, .11, 0, 1) !important;
                 filter: blur(0px) !important;
             }

--- a/src/plugins/BlurNSFW/index.js
+++ b/src/plugins/BlurNSFW/index.js
@@ -19,7 +19,8 @@ module.exports = (Plugin, Api) => {
             }
             
             img.blur,
-            video.blur {
+            video.blur,
+            a:hover + div > .blur {
                 filter: blur({{size}}px) !important;
                 transition: {{time}}ms cubic-bezier(.2, .11, 0, 1) !important;
             }`;


### PR DESCRIPTION
Discord made a change that makes an `a` element be hover-able when not clicked onto the image. At least, that's what I fixed to get it to work lol.