### PR TITLE
[PermissionsViewer] Fix overflow screen bug

### DIFF
--- a/src/plugins/PermissionsViewer/styles.css
+++ b/src/plugins/PermissionsViewer/styles.css
@@ -112,6 +112,7 @@
 }
 
 #permissions-modal-wrapper .modal-body {
+    max-height: 80vh;
     background-color: #36393f;
     height: 440px;
     width: auto;

--- a/src/plugins/PermissionsViewer/styles.css
+++ b/src/plugins/PermissionsViewer/styles.css
@@ -112,7 +112,6 @@
 }
 
 #permissions-modal-wrapper .modal-body {
-    max-height: 80vh;
     background-color: #36393f;
     height: 440px;
     width: auto;
@@ -126,9 +125,7 @@
 }
 
 #permissions-modal-wrapper #permissions-modal {
-    display: flex;
     contain: layout;
-    flex-direction: column;
     pointer-events: auto;
     border: 1px solid rgba(28,36,43,.6);
     border-radius: 5px;


### PR DESCRIPTION
This PR will fix the bug where the permission viewer modal will overflow the screen.

<details>
  <summary>Before</summary>

  <img width="440" alt="image" src="https://user-images.githubusercontent.com/27970303/163975796-6aab51a8-d00e-4ba7-827a-66ce3f64d4a8.png">
</details>

<details>
  <summary>After</summary>

  <img width="630" alt="image" src="https://user-images.githubusercontent.com/27970303/163977540-03042961-93f2-4678-80dd-4f1d89b7a80d.png">
</details>

closes #574