### PR TITLE
[RoleMembers] Fixed opening member list

### DIFF
--- a/Plugins/RoleMembers/RoleMembers.plugin.js
+++ b/Plugins/RoleMembers/RoleMembers.plugin.js
@@ -233,7 +233,7 @@ module.exports = (() => {
             if (this.listener) this.listener({target: {classList: {contains: () => {}}, closest: () => {}}}); // Close any previous popouts
             
             if (document.querySelector(`#app-mount > ${DiscordSelectors.TooltipLayers.layerContainer}`) != null)
-                document.querySelector(`#app-mount > ${DiscordSelectors.TooltipLayers.layerContainer}`).append(popout)
+                document.querySelector(`#app-mount > ${DiscordSelectors.TooltipLayers.layerContainer}`).append(popout);
             else
                 document.querySelector(`#app-mount`).querySelector(`${DiscordSelectors.TooltipLayers.layerContainer}`).appendChild(popout);
 

--- a/Plugins/RoleMembers/RoleMembers.plugin.js
+++ b/Plugins/RoleMembers/RoleMembers.plugin.js
@@ -232,7 +232,10 @@ module.exports = (() => {
         showPopout(popout, relativeTarget) {
             if (this.listener) this.listener({target: {classList: {contains: () => {}}, closest: () => {}}}); // Close any previous popouts
             
-            document.querySelector(`#app-mount > ${DiscordSelectors.TooltipLayers.layerContainer}`).append(popout);
+            if (document.querySelector(`#app-mount > ${DiscordSelectors.TooltipLayers.layerContainer}`) != null)
+                document.querySelector(`#app-mount > ${DiscordSelectors.TooltipLayers.layerContainer}`).append(popout)
+            else
+                document.querySelector(`#app-mount`).querySelector(`${DiscordSelectors.TooltipLayers.layerContainer}`).appendChild(popout);
 
             const maxWidth = Math.max(document.documentElement.clientWidth, window.innerWidth || 0);
             const maxHeight = Math.max(document.documentElement.clientHeight, window.innerHeight || 0);


### PR DESCRIPTION
My Discord does not detect the class added with `DiscordSelectors.TooltipLayers.layerContainer` because it returned null when it ran document.querySelector (`# app-mount> $ {DiscordSelectors.TooltipLayers.layerContainer}`)