### PR TITLE
Patch pv

### DIFF
--- a/src/plugins/PermissionsViewer/config.json
+++ b/src/plugins/PermissionsViewer/config.json
@@ -12,9 +12,14 @@
         "github": "https://github.com/rauenzi/BetterDiscordAddons/tree/master/Plugins/PermissionsViewer",
         "github_raw": "https://raw.githubusercontent.com/rauenzi/BetterDiscordAddons/master/Plugins/PermissionsViewer/PermissionsViewer.plugin.js"
     },
-    "changelog": [
-        {"title": "Fixes", "type": "fixed", "items": ["Popouts and context menus should all work once again!"]}
-    ],
+    "changelog": [{
+        "title": "Fixes", 
+        "type": "fixed", 
+        "items": [
+            "Popouts and context menus should all work once again!",
+            "User popout will close after opening permissions modal"
+        ]
+    }],
     "defaultConfig": [
         {
             "type": "switch",

--- a/src/plugins/PermissionsViewer/config.json
+++ b/src/plugins/PermissionsViewer/config.json
@@ -7,7 +7,7 @@
             "github_username": "rauenzi",
             "twitter_username": "ZackRauen"
         }],
-        "version": "0.2.6",
+        "version": "0.2.7",
         "description": "Allows you to view a user's permissions. Thanks to Noodlebox for the idea!",
         "github": "https://github.com/rauenzi/BetterDiscordAddons/tree/master/Plugins/PermissionsViewer",
         "github_raw": "https://raw.githubusercontent.com/rauenzi/BetterDiscordAddons/master/Plugins/PermissionsViewer/PermissionsViewer.plugin.js"

--- a/src/plugins/PermissionsViewer/config.json
+++ b/src/plugins/PermissionsViewer/config.json
@@ -17,7 +17,8 @@
         "type": "fixed", 
         "items": [
             "Popouts and context menus should all work once again!",
-            "User popout will close after opening permissions modal"
+            "User popout will close after opening permissions modal",
+            "Better handling for long role names"
         ]
     }],
     "defaultConfig": [

--- a/src/plugins/PermissionsViewer/index.js
+++ b/src/plugins/PermissionsViewer/index.js
@@ -139,6 +139,8 @@ module.exports = (Plugin, Api) => {
             const popout = element.querySelector(`[class*="userPopout-"], [class*="userPopoutOuter-"]`) ?? element;
             if (!popout || !popout.matches(`[class*="userPopout-"], [class*="userPopoutOuter-"]`)) return;
             const props = Utilities.findInTree(ReactTools.getReactInstance(popout), m => m && m.user, {walkable: ["return", "memoizedProps"]});
+            if(!props.closePopout)
+                props.closePopout = Utilities.findInTree(ReactTools.getReactInstance(popout), m => m && m.closePopout, {walkable: ["return", "memoizedProps"]}).closePopout
             popoutMount(props);
         }
 

--- a/src/plugins/PermissionsViewer/index.js
+++ b/src/plugins/PermissionsViewer/index.js
@@ -120,6 +120,7 @@ module.exports = (Plugin, Api) => {
 
                 permBlock.querySelector(".perm-details").addEventListener("click", () => {
                     this.showModal(this.createModalUser(name, user, guild));
+                    props.closePopout();
                 });
                 let roleList = popout.querySelector(isSkin ? ".roles-3zC7MX" : UserPopoutSelectors.rolesList);
                 if (isSkin) roleList = roleList.parentElement;

--- a/src/plugins/PermissionsViewer/jumbo.css
+++ b/src/plugins/PermissionsViewer/jumbo.css
@@ -1,7 +1,3 @@
-#permissions-modal-wrapper #permissions-modal {
-    height: 840px;
-}
-
 #permissions-modal-wrapper #permissions-modal .perm-side {
     width: 500px;
 }

--- a/src/plugins/PermissionsViewer/styles.css
+++ b/src/plugins/PermissionsViewer/styles.css
@@ -37,10 +37,12 @@
 
 .perm-details-button {
     cursor: pointer;
-    height: 12px;
+    height: 100%;
 }
 
 .perm-details {
+	height: 20px;
+	background:var(--background-secondary);
     display: flex;
     justify-content: flex-end;
 }
@@ -108,11 +110,11 @@
     box-sizing: border-box;
     contain: content;
     justify-content: center;
-    top: 0;
-    left: 0;
-    bottom: 0;
-    right: 0;
-    opacity: 0;
+    top: 5%;
+    left: 5%;
+    bottom: 5%;
+    right: 5%;
+    opacity: 5%;
     pointer-events: none;
     position: absolute;
     user-select: none;
@@ -134,6 +136,7 @@
 
 #permissions-modal-wrapper #permissions-modal {
     contain: layout;
+    height: 100%;
     flex-direction: column;
     pointer-events: auto;
     border: 1px solid rgba(28,36,43,.6);
@@ -174,8 +177,8 @@
 }
 
 #permissions-modal-wrapper .role-side {
-    width: auto;
-    min-width: 150px;
+    max-width: 300px;
+    min-width: 200px;
     background: #2f3136;
     flex: 0 0 auto;
     overflow: hidden;
@@ -200,6 +203,8 @@
     margin-bottom: 5px;
     cursor: pointer;
     color: #dcddde;
+    word-break:break-all;
+    border: 1px solid #444;
 }
 
 #permissions-modal-wrapper .role-item:hover {
@@ -254,7 +259,6 @@
     margin-left: 10px;
 }
 
-
 .member-perms::-webkit-scrollbar-thumb, .member-perms::-webkit-scrollbar-track,
 #permissions-modal-wrapper *::-webkit-scrollbar-thumb, #permissions-modal-wrapper *::-webkit-scrollbar-track {
     background-clip: padding-box;
@@ -289,8 +293,6 @@
     height: 8px;
     width: 8px;
 }
-
-
 
 .theme-light #permissions-modal-wrapper #permissions-modal {
     background: #fff;


### PR DESCRIPTION
- Fixed UserPopout Staying open when Permissions Modal is opened. *(yeah sure, just one click to close it, but it's also one line of code)*

![image](https://user-images.githubusercontent.com/114232893/196007773-19282343-9d76-4df6-b878-4f81e204b473.png)
- Made the Permissions Modal Button a tad bit more easy to click.

![image](https://user-images.githubusercontent.com/114232893/196007817-70d822f8-4616-4fd0-be19-e560e602d865.png)
- Better Handling for the Modal height, scroll the permissions list if there's not enough space vertically.

![image](https://user-images.githubusercontent.com/114232893/196007930-803fa366-63af-4a63-bdb2-cb409ad082e9.png)
![image](https://user-images.githubusercontent.com/114232893/196007935-7f14bdcf-018a-490a-9d4b-7096a6e57a71.png)
- Better Handling for long role names, otherwise the modal can get as big as the screen preventing the user from closing the Modal completely.

![image](https://user-images.githubusercontent.com/114232893/196008005-b60625d2-f133-4f5e-b69e-fc8e5bd881e4.png)