### PR TITLE
Fix permission descriptions being cut off

### DIFF
--- a/src/plugins/PermissionsViewer/perms.ts
+++ b/src/plugins/PermissionsViewer/perms.ts
@@ -12,7 +12,7 @@ interface Description {
 interface PermissionSpecification {
     title: string;
     flag: bigint;
-    description: ((locale: string) => Description) | string[];
+    description: ((locale: string) => Description) | string[] | string;
 }
 
 interface PermissionSpecCategory {
@@ -62,7 +62,7 @@ export function getDefinitions(guildIdOrGuild?: string | Guild): PermissionCateg
         permissions: category.permissions.map(perm => ({
             id: Object.keys(DiscordPermissions).find(key => DiscordPermissions[key as keyof IDiscordPermissions] === perm.flag) ?? "",
             name: perm.title,
-            description: typeof perm.description === "function" ? perm.description(BdApi.Webpack.Stores.LocaleStore.locale).ast[0] : perm.description[0]
+            description: typeof perm.description === "function" ? perm.description(BdApi.Webpack.Stores.LocaleStore.locale).ast[0] : (Array.isArray(perm.description) ? perm.description[0] : (perm.description || ""))
         }))
     }));
 }


### PR DESCRIPTION
Fixes permission descriptions (such as "Mention @ everyone") being cut off to the first letter.
<img width="269" height="50" alt="image" src="https://github.com/user-attachments/assets/ae8b35c7-518b-4f63-9ca0-31ed541f4967" />
<img width="438" height="86" alt="image" src="https://github.com/user-attachments/assets/18125488-2dfa-4fc8-b1b3-cac40cd864a3" />
